### PR TITLE
Apply mhluska fix fastboot

### DIFF
--- a/app/initializers/ember-form-for-i18n.js
+++ b/app/initializers/ember-form-for-i18n.js
@@ -2,17 +2,18 @@ import Ember from 'ember';
 const { getOwner } = Ember;
 
 export function initialize(app) {
-  let i18n = null;
-
-  try {
-    i18n = getOwner(app).lookup('service:i18n');
-  } catch(e) {
-    i18n = app.__container__.lookup('service:i18n');
+  // HACK: This can be undefined in the FastBoot environment.
+  let owner = getOwner(app) || app.__container__;
+  if (!owner) {
+    return;
   }
 
-  if (i18n) {
-    app.inject('component', 'i18n', 'service:i18n');
+  let i18n = owner.lookup('service:i18n');
+  if (!i18n) {
+    return;
   }
+
+  app.inject('component', 'i18n', 'service:i18n');
 }
 
 export default {


### PR DESCRIPTION
This PR applies [the mhluska change](https://github.com/mhluska/ember-form-for/tree/fix-fastboot) to the i18n initializer.

- uses `let` (as opposed to `const`) to pass tests

This allows FastBoot-enabled projects to use `ember-form-for`.

(All the other commits without any change to `master` content is because an earlier PR made those changes with "new commit hashes". Sorry for making noise.)