### PR TITLE
Disable isDevelopingAddon

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ module.exports = {
     this._super.included(app);
   },
   isDevelopingAddon: function() {
-    return true;
+    return false;
   }
 };


### PR DESCRIPTION
  - this is relevant to users who use ember-template-lint - this fails their build

Ifall en Addon som ditt app-projekt använder har `isDevelopingAddon: true` så kommer alla "linting-fel" i addonen vara build-breaking för _din app_.